### PR TITLE
Add edge bounce and obstacle collision

### DIFF
--- a/genetisk/src/main/java/no/asmund/genetisk/Creature.java
+++ b/genetisk/src/main/java/no/asmund/genetisk/Creature.java
@@ -2,6 +2,8 @@ package no.asmund.genetisk;
 
 import javafx.scene.paint.Color;
 
+import no.asmund.genetisk.Obstacle;
+
 import static java.lang.Math.sqrt;
 
 public class Creature {
@@ -54,8 +56,31 @@ public class Creature {
     }
 
     void update() {
-        x = x + (float) ((Math.cos(Math.toRadians(angle)) * 2));
-        y = y + (float) ((Math.sin(Math.toRadians(angle)) * 2));
+        float dx = (float) ((Math.cos(Math.toRadians(angle)) * 2));
+        float dy = (float) ((Math.sin(Math.toRadians(angle)) * 2));
+
+        // Bounce when hitting canvas edges
+        if (x + dx < 0 || x + dx > StartApp.WIDTH) {
+            angle = 180 - angle;
+            dx = -dx;
+        }
+        if (y + dy < 0 || y + dy > StartApp.HEIGHT) {
+            angle = -angle;
+            dy = -dy;
+        }
+
+        // Test collision with obstacles
+        for (Obstacle o : StartApp.obstacles) {
+            if (o.collides(x + dx, y + dy)) {
+                angle = angle + 180;
+                dx = -dx;
+                dy = -dy;
+                break;
+            }
+        }
+
+        x += dx;
+        y += dy;
         angle += dna.genes[geneCounter];
     }
 }

--- a/genetisk/src/main/java/no/asmund/genetisk/Obstacle.java
+++ b/genetisk/src/main/java/no/asmund/genetisk/Obstacle.java
@@ -1,0 +1,27 @@
+package no.asmund.genetisk;
+
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
+
+public class Obstacle {
+    final int x;
+    final int y;
+    final int width;
+    final int height;
+
+    public Obstacle(int x, int y, int width, int height) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+    }
+
+    public boolean collides(float px, float py) {
+        return px >= x && px <= x + width && py >= y && py <= y + height;
+    }
+
+    public void draw(GraphicsContext gc) {
+        gc.setFill(Color.GRAY);
+        gc.fillRect(x, y, width, height);
+    }
+}

--- a/genetisk/src/main/java/no/asmund/genetisk/StartApp.java
+++ b/genetisk/src/main/java/no/asmund/genetisk/StartApp.java
@@ -10,10 +10,13 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.util.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import no.asmund.genetisk.Obstacle;
 
 public class StartApp extends Application {
-    private final int HEIGHT = 600;
-    private final int WIDTH = 1200;
+    public static final int HEIGHT = 600;
+    public static final int WIDTH = 1200;
     public static int lifetime;
     private int lifecycle;
     public static int popNr;
@@ -21,6 +24,7 @@ public class StartApp extends Application {
     private Timeline loop;
     private Population population;
     public static int targetX, targetY;
+    public static List<Obstacle> obstacles = new ArrayList<>();
 
     @Override
     public void start(Stage primaryStage) {
@@ -30,6 +34,8 @@ public class StartApp extends Application {
 
         targetX = 1000;
         targetY = HEIGHT/2;
+
+        obstacles.add(new Obstacle(WIDTH/2 - 50, HEIGHT/2 - 20, 100, 40));
 
         StackPane root = new StackPane();
         Scene scene = new Scene(root, WIDTH, HEIGHT);
@@ -65,6 +71,11 @@ public class StartApp extends Application {
 //        gc.clearRect(0, 0, WIDTH, HEIGHT);
         gc.setFill(Color.RED);
         gc.fillRect(targetX - 5, targetY - 5, 10, 10);
+
+        for (Obstacle o : obstacles) {
+            o.draw(gc);
+        }
+
         gc.setFill(Color.BLACK);
         for (int i = 0; i < popNr; i++) {
             Creature r = population.population[i];


### PR DESCRIPTION
## Summary
- make canvas size constants in `StartApp` public
- add a simple `Obstacle` class
- maintain a list of obstacles and draw them
- bounce `Creature` off canvas edges and obstacles

## Testing
- `mvn -q -f genetisk/pom.xml -DskipTests=true package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0d911408323b4603d7ce58a6c74